### PR TITLE
Cap results to a max of 20

### DIFF
--- a/lib/practice_search_index.rb
+++ b/lib/practice_search_index.rb
@@ -77,7 +77,7 @@ class PracticeSearchIndex
         scores.max,
         scores,
       ]
-    }.reverse
+    }.reverse.take(max_results)
   end
 
 private

--- a/server.rb
+++ b/server.rb
@@ -20,6 +20,7 @@ SEARCH_INDEX = PracticeSearchIndex.new(
     practices: PRACTICES,
     practitioners: PRACTITIONERS,
   ).call,
+  max_results: 20,
 )
 
 def all_practices


### PR DESCRIPTION
Previously we were getting a maximum of 10 results for each of practice name, practice address, and practitioner name, and then combining them all into a single list and sorting.

That meant that the first 10 results would be of pretty high quality, but they could quickly fall off after that.

Getting 20 result of each type and then returning only the 20 best results should improve the consistency of result quality.

It would probably be better to use a quality threshold instead of an arbitrary count.
