### PR TITLE
Tidy up javascript imports and urls

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -11,10 +11,10 @@
   <link type="text/css" rel="stylesheet" href="http://fast.fonts.net/cssapi/e3854e97-b35c-4f31-bf5d-f804408f2ef8.css"/>
   <link href="/stylesheets/nhsuk.css" media="screen" rel="stylesheet" type="text/css" />
   <link href="/stylesheets/widget.css" media="screen" rel="stylesheet" type="text/css" />
-  <script src="javascripts/react.js"></script>
-  <script src="javascripts/react-dom.js"></script>
-  <script src="javascripts/jquery-2.2.0.js"></script>
-  <script src="javascripts/components.js"></script>
+  <script src="/javascripts/react.js"></script>
+  <script src="/javascripts/react-dom.js"></script>
+  <script src="/javascripts/jquery-2.2.0.js"></script>
+  <script src="/javascripts/components.js"></script>
 
   <!--[if lt IE 9]>
     <script src="/javascripts/vendor/html5shiv.js" type="text/javascript"></script>
@@ -84,8 +84,8 @@
   </div>
 </footer>
 
-<script src="javascripts/lookup.js"></script>
-<script type="text/javascript" src="/javascripts/cookies.js"></script>
+<script src="/javascripts/lookup.js"></script>
+<script src="/javascripts/cookies.js"></script>
 
 <% if GOOGLE_ANALYTICS_TRACKING_ID %>
   <%= erb :google_analytics %>

--- a/views/practice.erb
+++ b/views/practice.erb
@@ -100,8 +100,7 @@
   </div>
 </footer>
 
-<script src="javascripts/lookup.js"></script>
-<script type="text/javascript" src="/javascripts/cookies.js"></script>
+<script src="/javascripts/cookies.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Making the js paths root-relative.
Removing `lookup.js` from `/practice` as it's not needed.